### PR TITLE
Fixed location response header bug

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "none"
 }

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Data Client for Google Tag Manager Server Side
 
-Data Client developed for receiving requests from [Data Tag](https://github.com/stape-io/data-tag) placed inside the Google Tag Manager Web Container, but also can receive any request and map it to event data inside the Google Tag Manager Server Side container. 
+Data Client developed for receiving requests from [Data Tag](https://github.com/stape-io/data-tag) placed inside the Google Tag Manager Web Container, but it can also receive any request and map it to the Event Data inside the Google Tag Manager Server Side container.
 
-### Useful links: 
+## Useful resources
 
 - https://stape.io/solutions/data-tag-client
-- https://stape.io/blog/sending-data-from-google-tag-manager-web-container-to-the-server-container 
-- https://stape.io/blog/send-datalayer-push-from-server-gtm-to-web-gtm 
+- https://stape.io/blog/sending-data-from-google-tag-manager-web-container-to-the-server-container
+- https://stape.io/blog/send-datalayer-push-from-server-gtm-to-web-gtm
 
 ## Open Source
 
-Data Client for Google Tag Manager Server Side is developing and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
+Data Client for Google Tag Manager Server Side is developed and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 homepage: "https://stape.io/"
 versions:
-  - sha: bcc2b5079ff0bad4fbe36276c8652fe3209f288d
+  - sha: a9fb729fd9eed2013188c00e820fa81aa78e71c1
     changeNotes: Fixed location response header bug.
   - sha: e31d2f39c10285cbc5169e349c473f73e4668692
     changeNotes: Added support for x-www-form-urlencoded.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: bcc2b5079ff0bad4fbe36276c8652fe3209f288d
+    changeNotes: Fixed location response header bug.
   - sha: e31d2f39c10285cbc5169e349c473f73e4668692
     changeNotes: Added support for x-www-form-urlencoded.
   - sha: 4d9f4d4fbded5414cb091efac70224d31c522e5c

--- a/template.js
+++ b/template.js
@@ -47,7 +47,7 @@ function runClient() {
   require('claimRequest')();
 
   if (requestMethod === 'OPTIONS') {
-    setResponseHeaders(200);
+    setCommonResponseHeaders(200);
     returnResponse();
     return;
   }
@@ -65,7 +65,7 @@ function runClient() {
   exposeFPIDCookie(eventModels[0]);
   prolongDataTagCookies(eventModels[0]);
   const responseStatusCode = makeInteger(data.responseStatusCode);
-  setResponseHeaders(responseStatusCode);
+  setCommonResponseHeaders(responseStatusCode);
 
   Promise.all(
     eventModels.map((eventModel) => {
@@ -387,7 +387,7 @@ function storeClientId(eventModel) {
       samesite: getCookieType(eventModel),
       secure: true,
       'max-age': 63072000, // 2 years
-      httpOnly: data.httpOnlyCookie || false,
+      httpOnly: data.httpOnlyCookie || false
     });
   }
 }
@@ -403,7 +403,7 @@ function getObjectLength(object) {
   return length;
 }
 
-function setResponseHeaders(statusCode) {
+function setCommonResponseHeaders(statusCode) {
   setResponseHeader('Access-Control-Max-Age', '600');
   setResponseHeader('Access-Control-Allow-Origin', getRequestHeader('origin'));
   setResponseHeader(
@@ -505,14 +505,13 @@ function getEcommerceAction(eventModel) {
 
 function setRedirectLocation() {
   let location = data.redirectTo;
-
   if (data.lookupForRedirectToParam && data.redirectToQueryParamName) {
     const param = getRequestQueryParameter(data.redirectToQueryParamName);
     if (param && param.startsWith('http')) {
       location = param;
     }
   }
-  setResponseHeaders('location', location);
+  setResponseHeader('location', location);
 }
 
 function setClientErrorResponseMessage() {

--- a/template.js
+++ b/template.js
@@ -342,7 +342,7 @@ function prolongDataTagCookies(eventModel) {
         samesite: getCookieType(eventModel),
         secure: true,
         'max-age': 63072000, // 2 years
-        httpOnly: false,
+        httpOnly: false
       });
     }
   }
@@ -373,7 +373,7 @@ function exposeFPIDCookie(eventModel) {
         samesite: getCookieType(eventModel),
         secure: true,
         'max-age': 63072000, // 2 years
-        httpOnly: false,
+        httpOnly: false
       });
     }
   }
@@ -460,7 +460,7 @@ function prepareResponseBody(eventModels) {
     setResponseBody(
       JSON.stringify({
         timestamp: responseModel.timestamp,
-        unique_event_id: responseModel.unique_event_id,
+        unique_event_id: responseModel.unique_event_id
       })
     );
     return;
@@ -471,7 +471,7 @@ function prepareResponseBody(eventModels) {
       eventModels.map((eventModel) => {
         return {
           timestamp: eventModel.timestamp,
-          unique_event_id: eventModel.unique_event_id,
+          unique_event_id: eventModel.unique_event_id
         };
       })
     )
@@ -488,7 +488,7 @@ function getEcommerceAction(eventModel) {
       'checkout',
       'checkout_option',
       'purchase',
-      'refund',
+      'refund'
     ];
 
     for (let index = 0; index < actions.length; ++index) {
@@ -542,7 +542,7 @@ function getEventModels(baseEventModel) {
         const eventModel = assign({}, baseEventModel, {
           timestamp: makeInteger(getTimestampMillis() / 1000),
           unique_event_id:
-            getTimestampMillis() + '_' + generateRandom(100000000, 999999999),
+            getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
         });
         for (let bodyItemKey in bodyItem) {
           eventModel[bodyItemKey] = bodyItem[bodyItemKey];
@@ -556,8 +556,8 @@ function getEventModels(baseEventModel) {
     assign({}, baseEventModel, {
       timestamp: makeInteger(getTimestampMillis() / 1000),
       unique_event_id:
-        getTimestampMillis() + '_' + generateRandom(100000000, 999999999),
-    }),
+        getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
+    })
   ];
 }
 

--- a/template.tpl
+++ b/template.tpl
@@ -331,7 +331,7 @@ function runClient() {
   require('claimRequest')();
 
   if (requestMethod === 'OPTIONS') {
-    setResponseHeaders(200);
+    setCommonResponseHeaders(200);
     returnResponse();
     return;
   }
@@ -349,7 +349,7 @@ function runClient() {
   exposeFPIDCookie(eventModels[0]);
   prolongDataTagCookies(eventModels[0]);
   const responseStatusCode = makeInteger(data.responseStatusCode);
-  setResponseHeaders(responseStatusCode);
+  setCommonResponseHeaders(responseStatusCode);
 
   Promise.all(
     eventModels.map((eventModel) => {
@@ -687,7 +687,7 @@ function getObjectLength(object) {
   return length;
 }
 
-function setResponseHeaders(statusCode) {
+function setCommonResponseHeaders(statusCode) {
   setResponseHeader('Access-Control-Max-Age', '600');
   setResponseHeader('Access-Control-Allow-Origin', getRequestHeader('origin'));
   setResponseHeader(
@@ -789,14 +789,13 @@ function getEcommerceAction(eventModel) {
 
 function setRedirectLocation() {
   let location = data.redirectTo;
-
   if (data.lookupForRedirectToParam && data.redirectToQueryParamName) {
     const param = getRequestQueryParameter(data.redirectToQueryParamName);
     if (param && param.startsWith('http')) {
       location = param;
     }
   }
-  setResponseHeaders('location', location);
+  setResponseHeader('location', location);
 }
 
 function setClientErrorResponseMessage() {
@@ -1227,5 +1226,4 @@ setup: ''
 ___NOTES___
 
 Created on 21/03/2021, 11:24:30
-
 

--- a/template.tpl
+++ b/template.tpl
@@ -626,7 +626,7 @@ function prolongDataTagCookies(eventModel) {
         samesite: getCookieType(eventModel),
         secure: true,
         'max-age': 63072000, // 2 years
-        httpOnly: false,
+        httpOnly: false
       });
     }
   }
@@ -657,7 +657,7 @@ function exposeFPIDCookie(eventModel) {
         samesite: getCookieType(eventModel),
         secure: true,
         'max-age': 63072000, // 2 years
-        httpOnly: false,
+        httpOnly: false
       });
     }
   }
@@ -744,7 +744,7 @@ function prepareResponseBody(eventModels) {
     setResponseBody(
       JSON.stringify({
         timestamp: responseModel.timestamp,
-        unique_event_id: responseModel.unique_event_id,
+        unique_event_id: responseModel.unique_event_id
       })
     );
     return;
@@ -755,7 +755,7 @@ function prepareResponseBody(eventModels) {
       eventModels.map((eventModel) => {
         return {
           timestamp: eventModel.timestamp,
-          unique_event_id: eventModel.unique_event_id,
+          unique_event_id: eventModel.unique_event_id
         };
       })
     )
@@ -772,7 +772,7 @@ function getEcommerceAction(eventModel) {
       'checkout',
       'checkout_option',
       'purchase',
-      'refund',
+      'refund'
     ];
 
     for (let index = 0; index < actions.length; ++index) {
@@ -826,7 +826,7 @@ function getEventModels(baseEventModel) {
         const eventModel = assign({}, baseEventModel, {
           timestamp: makeInteger(getTimestampMillis() / 1000),
           unique_event_id:
-            getTimestampMillis() + '_' + generateRandom(100000000, 999999999),
+            getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
         });
         for (let bodyItemKey in bodyItem) {
           eventModel[bodyItemKey] = bodyItem[bodyItemKey];
@@ -840,8 +840,8 @@ function getEventModels(baseEventModel) {
     assign({}, baseEventModel, {
       timestamp: makeInteger(getTimestampMillis() / 1000),
       unique_event_id:
-        getTimestampMillis() + '_' + generateRandom(100000000, 999999999),
-    }),
+        getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
+    })
   ];
 }
 


### PR DESCRIPTION
Hi.

There was a typo in the code that prevented the response header from being properly set and caused an exception to be raised.

The `setResponseHeader**s**` custom function was being called from within the `setRedirectLocation` function. However, the correct function should've been the `setResponseHeader`, which is the default API method.

I renamed the `setResponseHeader**s**` to `setCommonResponseHeaders` and also started using `setResponseHeader` when setting the `location` header.