### PR TITLE
Fix timestamp and unique_event_id override

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: 953bf24c77b68e708fee1e953eea31303bf1fde1
+    changeNotes: Fix for timestamp and unique_event_id override.
   - sha: a9fb729fd9eed2013188c00e820fa81aa78e71c1
     changeNotes: Fixed location response header bug.
   - sha: e31d2f39c10285cbc5169e349c473f73e4668692

--- a/template.js
+++ b/template.js
@@ -539,11 +539,14 @@ function getEventModels(baseEventModel) {
       }
 
       return bodyJson.map((bodyItem) => {
-        const eventModel = assign({}, baseEventModel, {
-          timestamp: makeInteger(getTimestampMillis() / 1000),
-          unique_event_id:
-            getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
-        });
+        const eventModel = assign(
+          {
+            timestamp: makeInteger(getTimestampMillis() / 1000),
+            unique_event_id:
+              getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
+          },
+          baseEventModel
+        );
         for (let bodyItemKey in bodyItem) {
           eventModel[bodyItemKey] = bodyItem[bodyItemKey];
         }
@@ -553,11 +556,14 @@ function getEventModels(baseEventModel) {
   }
 
   return [
-    assign({}, baseEventModel, {
-      timestamp: makeInteger(getTimestampMillis() / 1000),
-      unique_event_id:
-        getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
-    })
+    assign(
+      {
+        timestamp: makeInteger(getTimestampMillis() / 1000),
+        unique_event_id:
+          getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
+      },
+      baseEventModel
+    )
   ];
 }
 

--- a/template.tpl
+++ b/template.tpl
@@ -823,11 +823,14 @@ function getEventModels(baseEventModel) {
       }
 
       return bodyJson.map((bodyItem) => {
-        const eventModel = assign({}, baseEventModel, {
-          timestamp: makeInteger(getTimestampMillis() / 1000),
-          unique_event_id:
-            getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
-        });
+        const eventModel = assign(
+          {
+            timestamp: makeInteger(getTimestampMillis() / 1000),
+            unique_event_id:
+              getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
+          },
+          baseEventModel
+        );
         for (let bodyItemKey in bodyItem) {
           eventModel[bodyItemKey] = bodyItem[bodyItemKey];
         }
@@ -837,11 +840,14 @@ function getEventModels(baseEventModel) {
   }
 
   return [
-    assign({}, baseEventModel, {
-      timestamp: makeInteger(getTimestampMillis() / 1000),
-      unique_event_id:
-        getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
-    })
+    assign(
+      {
+        timestamp: makeInteger(getTimestampMillis() / 1000),
+        unique_event_id:
+          getTimestampMillis() + '_' + generateRandom(100000000, 999999999)
+      },
+      baseEventModel
+    )
   ];
 }
 


### PR DESCRIPTION
This pull request includes changes to fix the timestamp and unique_event_id override in event models, as well as refactoring the `assign` function calls in `template.js` and `template.tpl`. The most important changes are summarized below:

Fixes and Improvements:

* [`metadata.yaml`](diffhunk://#diff-d186204ea7abb85bbadd9d94ab29d5bcefcc43d6a0ed06015e98a71b2f099423R3-R4): Added a new version entry with a fix for timestamp and unique_event_id override.

Refactoring:

* [`template.js`](diffhunk://#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210L542-R549): Refactored the `assign` function call in the `getEventModels` function avoid `baseEventModel` fields override [[1]](diffhunk://#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210L542-R549) [[2]](diffhunk://#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210L556-R566)